### PR TITLE
Make the TEXLIVE_RELEASE environment variable a workflow input parameter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-on: 
+on:
   workflow_call:
     inputs:
       bookname:
@@ -13,12 +13,16 @@ on:
         description: 'Create a release and upload the artifacts to it (needs token)'
         default: true
         type: boolean
-        
+      texlive_release:
+        description: 'The TeX Live release to use for the build ("YYYY" or "rolling")'
+        default: '2023'
+        type: string
+
 jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      TEXLIVE_RELEASE: '2023'
+      TEXLIVE_RELEASE: ${{ inputs.texlive_release }}
     
     steps:
 


### PR DESCRIPTION
It is not currently possible to run the `main` GitHub Actions workflows of the various books because TeX Live is hardcoded to "2023", and they now require a later TeX Live release.

This PR makes the `TEXLIVE_RELEASE` env variable settable, defaulting to the original '2023'.

For example I was able to build 'Application Building with Spec 2.0' in [this branch](https://github.com/SquareBracketAssociates/BuildingApplicationWithSpec2/compare/master...AndrzejProchyra:BuildingApplicationWithSpec2:set-build-script-executable) by:
1. Setting TeX Live to the 2025 release
2. Making the `_support/latex/sbabook/ci/install-texlive` script executible

Note: I did not use the 2026 TeX Live release because the `install-texlive` script currently assumes a `tlnet-final` directory on the distribution FTP server, which the 2026 release does not have. (See https://github.com/SquareBracketAssociates/BuildingApplicationWithSpec2/blob/2585775df7afc744100889174044ba80cffe8df5/_support/latex/sbabook/ci/install-texlive#L22)